### PR TITLE
extended resource-pack support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "cloud.grabsky"
-version = "1.20.2-${System.getenv("GITHUB_RUN_NUMBER") ?: "dev"}"
+version = "1.20.4-${System.getenv("GITHUB_RUN_NUMBER") ?: "dev"}"
 
 subprojects {
     apply(plugin: "java-library")
@@ -16,7 +16,7 @@ subprojects {
 
     ext {
         BEDROCK_VERSION = "1.20.1-47"
-        KYORI_NBT_VERSION = "4.14.0"
+        KYORI_NBT_VERSION = "4.15.0"
     }
 
     repositories {
@@ -32,7 +32,7 @@ subprojects {
         compileOnly("org.projectlombok:lombok:1.18.26")
         annotationProcessor("org.projectlombok:lombok:1.18.26")
         // Paper API
-        compileOnly("io.papermc.paper:paper-api:1.20.2-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     }
 
 }

--- a/plugin/src/main/java/cloud/grabsky/azure/Azure.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/Azure.java
@@ -99,6 +99,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -312,7 +313,7 @@ public final class Azure extends BedrockPlugin implements AzureAPI, Listener {
             }
             // Returning 'true' as reload finished without any exceptions.
             return true;
-        } catch (final IllegalStateException | ConfigurationMappingException | IOException e) {
+        } catch (final IllegalStateException | ConfigurationMappingException | IOException | URISyntaxException e) {
             this.getLogger().severe("An error occured while trying to reload plugin.");
             this.getLogger().severe("  " + e.getMessage());
             return false;

--- a/plugin/src/main/java/cloud/grabsky/azure/commands/EnderchestCommand.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/commands/EnderchestCommand.java
@@ -30,9 +30,7 @@ import cloud.grabsky.commands.RootCommand;
 import cloud.grabsky.commands.RootCommandContext;
 import cloud.grabsky.commands.annotation.Command;
 import cloud.grabsky.commands.component.CompletionsProvider;
-import cloud.grabsky.commands.component.ExceptionHandler;
 import cloud.grabsky.commands.exception.CommandLogicException;
-import cloud.grabsky.commands.exception.MissingInputException;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 

--- a/plugin/src/main/java/cloud/grabsky/azure/commands/KickCommand.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/commands/KickCommand.java
@@ -26,7 +26,6 @@ package cloud.grabsky.azure.commands;
 import cloud.grabsky.azure.Azure;
 import cloud.grabsky.azure.configuration.PluginConfig;
 import cloud.grabsky.azure.configuration.PluginLocale;
-import cloud.grabsky.azure.user.AzureUser;
 import cloud.grabsky.azure.user.AzureUser.DiscordLogger;
 import cloud.grabsky.bedrock.components.Message;
 import cloud.grabsky.commands.ArgumentQueue;

--- a/plugin/src/main/java/cloud/grabsky/azure/commands/PackCommand.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/commands/PackCommand.java
@@ -59,44 +59,7 @@ public final class PackCommand extends RootCommand {
 
     @Override
     public void onCommand(final @NotNull RootCommandContext context, final @NotNull ArgumentQueue arguments) throws CommandLogicException {
-        switch (arguments.next(String.class).asOptional("help").toLowerCase()) {
-            case "apply" -> {
-                // Sending resource pack 1 tick after event is fired. (if enabled)
-                if (plugin.getResourcePackManager().getFile() == null || plugin.getResourcePackManager().getHash() == null) {
-                    plugin.getLogger().severe("Could not send resourcepack as it seems to be either non-existent or defined improperly.");
-                    return;
-                }
-                plugin.getBedrockScheduler().run(1L, (task) -> context.getExecutor().asPlayer().setResourcePack(
-                        "http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT + "/" + plugin.getResourcePackManager().getToken(),
-                        plugin.getResourcePackManager().getHash(),
-                        PluginConfig.RESOURCE_PACK_IS_REQUIRED,
-                        PluginConfig.RESOURCE_PACK_PROMPT_MESSAGE
-                ));
-            }
-            case "notify" -> {
-                final CommandSender sender = context.getExecutor().asCommandSender();
-                // ...
-                if (sender.hasPermission(this.getPermission() + ".notify") == true) {
-                    final boolean isConfirm = arguments.next(String.class).asOptional("").equalsIgnoreCase("--confirm");
-                    // Checking for --confirm flag.
-                    if (isConfirm == true) {
-                        // Getting the server audience.
-                        final Server server = plugin.getServer();
-                        // Playing notification sound.
-                        if (PluginConfig.RESOURCE_PACK_NOTIFICATION_SOUND != null)
-                            server.playSound(PluginConfig.RESOURCE_PACK_NOTIFICATION_SOUND);
-                        // Sending notification message.
-                        Message.of(PluginLocale.COMMAND_PACK_NOTIFICATION).send(server);
-                        return;
-                    }
-                    Message.of(PluginLocale.COMMAND_PACK_NOTIFY_CONFIRM).replace("<input>", context.getInput().toString()).send(sender);
-                    return;
-                }
-                Message.of(PluginLocale.MISSING_PERMISSIONS).send(sender);
-            }
-            // Showing help page when invalid argument is provided.
-            default -> Message.of(PluginLocale.COMMAND_PACK_HELP).send(context.getExecutor().asCommandSender());
-        }
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/plugin/src/main/java/cloud/grabsky/azure/configuration/PluginConfig.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/configuration/PluginConfig.java
@@ -135,8 +135,8 @@ public final class PluginConfig implements JsonConfiguration {
     @JsonPath("resource_pack.port")
     public static int RESOURCE_PACK_PORT;
 
-    @JsonPath("resource_pack.pack_file")
-    public static String RESOURCE_PACK_FILE;
+    @JsonPath("resource_pack.pack_files")
+    public static List<String> RESOURCE_PACK_FILES;
 
     @JsonPath("resource_pack.send_on_join")
     public static boolean RESOURCE_PACK_SEND_ON_JOIN;

--- a/plugin/src/main/java/cloud/grabsky/azure/resourcepack/ResourcePackManager.java
+++ b/plugin/src/main/java/cloud/grabsky/azure/resourcepack/ResourcePackManager.java
@@ -30,8 +30,9 @@ import cloud.grabsky.azure.configuration.PluginConfig;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -42,7 +43,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import lombok.AccessLevel;
@@ -50,89 +57,103 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
-public final class ResourcePackManager implements Listener, HttpHandler {
+public final class ResourcePackManager implements Listener {
 
     private final Azure plugin;
 
-    @Getter(AccessLevel.PUBLIC)
-    private @Nullable String token;
-
-    @Getter(AccessLevel.PUBLIC)
-    private @Nullable File file;
-
-    @Getter(AccessLevel.PUBLIC)
-    private @Nullable String hash;
-
     private @Nullable HttpServer server;
 
+    private final List<ResourcePackHolder> holders = new ArrayList<>();
 
-    public void reload() throws IOException {
-        this.file = Path.of(plugin.getDataFolder().getPath(), ".public_resourcepack", PluginConfig.RESOURCE_PACK_FILE).toFile();
-        // Hashing file.
-        if (file.exists() == true && file.isDirectory() == false)
-            this.hash = Files.asByteSource(file).hash(Hashing.sha1()).toString();
+
+    @SuppressWarnings("deprecation") // Providing SHA-1 is required by the client, despite it being insecure.
+    public void reload() throws IOException, URISyntaxException {
+        holders.clear();
+        // Re-calculating hashes...
+        for (final String filename : PluginConfig.RESOURCE_PACK_FILES) {
+            final File file = Path.of(plugin.getDataFolder().getPath(), ".public", filename).toFile();
+            // Hashing file.
+            if (file.exists() == true && file.isDirectory() == false) {
+                final UUID uniqueId = UUID.nameUUIDFromBytes(file.getName().getBytes(StandardCharsets.UTF_8));
+                // ...
+                holders.add(new ResourcePackHolder(uniqueId, file, Files.asByteSource(file).hash(Hashing.sha1()).toString()));
+            }
+        }
         // Setting-up internal web server throws BindException in case port is already in use.
         if (PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS.isBlank() == false && PluginConfig.RESOURCE_PACK_PORT > 0 && this.server == null) {
             this.server = HttpServer.create(new InetSocketAddress(PluginConfig.RESOURCE_PACK_PORT), 0);
-            // Generating initial token.
-            this.token = UUID.randomUUID().toString();
-            // Configuring the server to be accessible only at unique-per-runtime path.
-            server.createContext("/" + token, this);
             // Configuring the server to automatically close connections at any other paths.
             server.createContext("/", HttpExchange::close);
             // Starting the server.
             server.start();
             // ...
-            plugin.getLogger().info("Internal web server started and should be accessible at http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT + "/" + token);
-            // Starting token rotation task.
-            plugin.getBedrockScheduler().repeat(1200L, 1200L, Long.MAX_VALUE, (task) -> {
-                if (this.server == null)
-                    return false;
-                // Generating new token.
-                final String newToken = UUID.randomUUID().toString();
-                // Configuring the server to be accessible at the new path.
-                server.createContext("/" + newToken, this);
-                // Removing HttpContext associated with previous token.
-                server.removeContext("/" + token);
-                // Replacing previous token with a new one.
-                this.token = newToken;
-                // Returning 'true' as to continue future executions of this task.
-                return true;
-            });
+            plugin.getLogger().info("Internal web server started and should be accessible at http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT);
         }
-    }
-
-    @Override
-    public void handle(final @NotNull HttpExchange exchange) throws IOException {
-        // Opening FileInputStream for the resource-pack file.
-        final FileInputStream in = new FileInputStream(file);
-        // Reading all bytes.
-        final byte[] bytes = in.readAllBytes();
-        // Closing the FileInputStream.
-        in.close();
-        // Responding with code 200 and bytes length.
-        exchange.sendResponseHeaders(200, bytes.length);
-        // Writing bytes (file) to the response.
-        exchange.getResponseBody().write(bytes);
-        // Closing the response.
-        exchange.getResponseBody().close();
     }
 
     // NOTE: This is likely to be moved onto configuration event once available. (1.20.2)
     @EventHandler(ignoreCancelled = true)
-    public void onPlayerJoin(final @NotNull PlayerJoinEvent event) {
+    public void onPlayerJoin(final @NotNull PlayerJoinEvent event) throws URISyntaxException {
         // Sending resource pack 1 tick after event is fired. (if enabled)
-        if (PluginConfig.RESOURCE_PACK_SEND_ON_JOIN == true) {
-            if (file == null || hash == null) {
-                plugin.getLogger().severe("Could not send resource-pack as it seems to be either non-existent or defined improperly.");
-                return;
-            }
-            plugin.getBedrockScheduler().run(1L, (task) -> event.getPlayer().setResourcePack(
-                    "http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT + "/" + token,
-                    hash,
-                    PluginConfig.RESOURCE_PACK_IS_REQUIRED,
-                    PluginConfig.RESOURCE_PACK_PROMPT_MESSAGE
+        if (PluginConfig.RESOURCE_PACK_SEND_ON_JOIN == true && this.server != null) {
+            // ...
+            plugin.getBedrockScheduler().run(1L, (task) -> event.getPlayer().sendResourcePacks(ResourcePackRequest.resourcePackRequest()
+                    .required(PluginConfig.RESOURCE_PACK_IS_REQUIRED)
+                    .prompt(PluginConfig.RESOURCE_PACK_PROMPT_MESSAGE)
+                    .packs(holders.stream().map(holder -> {
+                        final String secret = UUID.randomUUID().toString();
+                        // ...
+                        server.createContext("/" + secret, (exchange) -> {
+                            // Removing the exchange, preventing anyone else from using it.
+                            exchange.getHttpContext().getServer().removeContext("/" + secret);
+                            // Opening FileInputStream for the resource-pack file.
+                            final FileInputStream in = new FileInputStream(holder.file);
+                            // Reading all bytes.
+                            final byte[] bytes = in.readAllBytes();
+                            // Closing the FileInputStream.
+                            in.close();
+                            // Responding with code 200 and bytes length.
+                            exchange.sendResponseHeaders(200, bytes.length);
+                            // Writing bytes (file) to the response.
+                            exchange.getResponseBody().write(bytes);
+                            // Closing the response.
+                            exchange.getResponseBody().close();
+                        });
+                        // ...
+                        final @Nullable URI uri = toURI("http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT + "/" + secret);
+                        // ...
+                        if (uri == null) {
+                            plugin.getLogger().severe("Could not create URI: " + "http://" + PluginConfig.RESOURCE_PACK_PUBLIC_ACCESS_ADDRESS + ":" + PluginConfig.RESOURCE_PACK_PORT + "/" + secret);
+                            plugin.getLogger().severe("  Resource-pack " + holder.file.getName() + " will not be excluded from the request.");
+                            return null;
+                        }
+                        // ...
+                        return ResourcePackInfo.resourcePackInfo(holder.uniqueId, uri, holder.hash);
+                    }).filter(Objects::nonNull).toList()).build()
             ));
+        }
+    }
+
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    private static final class ResourcePackHolder {
+
+        @Getter(AccessLevel.PUBLIC)
+        private final UUID uniqueId;
+
+        @Getter(AccessLevel.PUBLIC)
+        private final File file;
+
+        @Getter(AccessLevel.PUBLIC)
+        private final String hash;
+
+    }
+
+    public static @Nullable URI toURI(final @NotNull String uri) {
+        try {
+            return new URI(uri);
+        } catch (final URISyntaxException ___) {
+            return null;
         }
     }
 

--- a/plugin/src/main/resources/config.json
+++ b/plugin/src/main/resources/config.json
@@ -80,7 +80,7 @@
         // Marks resource-packs as forced. Player won't be able to join the server without accepting them.
         "is_required": true,
         // Server message shown in the resource-pack prompt.
-        "prompt_message": "<red>Aby grać na naszym serwerze, musisz zaakceptować paczkę zasobów.",
+        "prompt_message": "\n<gray>Nasz serwer <red>wymaga<gray> akceptacji paczki zasobów.\n\n\n<gray>Listę zasobów, w tym zasobów <red>3rd-party<gray>, wraz z <red>autorami i licencjami<gray> znajdziesz w ustawieniach gry.",
         // Sound played when player is notified about resource-packs update.
         "notification_sound": { "key": "minecraft:block.note_block.bell", "source": "master", "volume": 1, "pitch": 0.5 }
     },

--- a/plugin/src/main/resources/config.json
+++ b/plugin/src/main/resources/config.json
@@ -70,17 +70,19 @@
     "resource_pack": {
         // Client must be able to access this address, otherwise resource-pack cannot be downloaded. This is NOT address that internal web server will be hosted at.
         "public_access_address": "",
-        // Port to host web-server supplying resource-pack on.
+        // Port to host web-server supplying resource-packs on.
         "port": 25578,
-        // Compressed resource-pack file inside "plugins/Azure/.public_resource-pack/".
-        "pack_file": "resourcepack.zip",
-        // Whether resource pack should be send when player joins the server.
+        // Compressed resource-pack files inside "plugins/Azure/.public/".
+        "pack_files": [
+            "resourcepack.zip"
+        ],
+        // Whether resource-pack should be send when player joins the server.
         "send_on_join": false,
-        // Marks the resource pack as forced. Player won't be able to join the server without accepting it.
+        // Marks the resource-packs as forced. Player won't be able to join the server without accepting it.
         "is_required": true,
-        // Server message shown in resource pack prompt.
+        // Server message shown in the resource-pack prompt.
         "prompt_message": "<red>Aby grać na naszym serwerze, musisz zaakceptować paczkę zasobów.",
-        // Sound played when player is notified
+        // Sound played when player is notified about resource-packs update.
         "notification_sound": { "key": "minecraft:block.note_block.bell", "source": "master", "volume": 1, "pitch": 0.5 }
     },
     // Hidden players are not removed from server list status. Consider setting 'hide-online-players' to 'true'. (server.properties)

--- a/plugin/src/main/resources/config.json
+++ b/plugin/src/main/resources/config.json
@@ -69,16 +69,15 @@
     },
     "resource_pack": {
         // Client must be able to access this address, otherwise resource-pack cannot be downloaded. This is NOT address that internal web server will be hosted at.
+        // Set to "" to disable the web-server functionality.
         "public_access_address": "",
         // Port to host web-server supplying resource-packs on.
         "port": 25578,
-        // Compressed resource-pack files inside "plugins/Azure/.public/".
-        "pack_files": [
-            "resourcepack.zip"
-        ],
+        // Names of compressed resource-pack files inside "plugins/Azure/.public/".
+        "pack_files": [],
         // Whether resource-pack should be send when player joins the server.
         "send_on_join": false,
-        // Marks the resource-packs as forced. Player won't be able to join the server without accepting it.
+        // Marks resource-packs as forced. Player won't be able to join the server without accepting them.
         "is_required": true,
         // Server message shown in the resource-pack prompt.
         "prompt_message": "<red>Aby grać na naszym serwerze, musisz zaakceptować paczkę zasobów.",


### PR DESCRIPTION
Some interesting features have been added in the recent Minecraft updates. More changes will come on a later date, not everything is supported by the API yet.

This PR basically re-writes how resource-packs are being handled:
- Internal web-server works "on-demand" now. It is a bit cleaner than previous "token-rotation" approach. May cause some performance issues and have not been fully tested *yet*.
- Internal web-server can now answer with more than one resource-pack, enabling ability to define mulitple server resource-packs.